### PR TITLE
Merge 558 fixes in

### DIFF
--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -280,6 +280,7 @@ mod tests {
     use crate::checkpoint::Checkpoint;
     use crate::config::{GarbageCollectorDirectoryOptions, GarbageCollectorOptions};
     use crate::error::SlateDBError;
+    use crate::object_stores::ObjectStores;
     use crate::paths::PathResolver;
     use crate::types::RowEntry;
     use crate::{


### PR DESCRIPTION
When I merged main into your branch, I noticed it began failing because some of the changes in 558 altered APIs in ways that weren't compatible. In particular, TableStore now takes `ObjectStores`. I've updated the code and disabled WAL object stores for `admin.rs` garbage collection stuff. This was the path we agreed to for the time being in #558.

I also found I had to re-add `Results` in a few spots because we're now validating that manifests don't have WAL object stores set.